### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fluent::Plugin::Format
+# Fluent::Plugin::Format, a plugin for [Fluentd](http://fluentd.org)
 
 Output plugin to format fields of records.
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
