### PR TITLE
Tweak for v0.14 Compatibile layer

### DIFF
--- a/fluent-plugin-format.gemspec
+++ b/fluent-plugin-format.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "fluentd"
+  spec.add_development_dependency "test-unit", "~> 3.2.0"
   spec.add_runtime_dependency "fluentd"
 end

--- a/lib/fluent/plugin/out_format.rb
+++ b/lib/fluent/plugin/out_format.rb
@@ -2,6 +2,11 @@ module Fluent
   class FormatOutput < Output
     Fluent::Plugin.register_output('format', self)
 
+    # Define `router` method of v0.12 to support v0.10 or earlier
+    unless method_defined?(:router)
+      define_method("router") { Fluent::Engine }
+    end
+
     config_param :tag, :string
     config_param :include_original_fields, :bool, :default => true
 
@@ -20,7 +25,7 @@ module Fluent
 
     def emit(tag, es, chain)
       es.each do |time, record|
-        Engine.emit(@tag, time, format_record(record))
+        router.emit(@tag, time, format_record(record))
       end
 
       chain.next


### PR DESCRIPTION
I've found that this plugin is not ready to work with Fluentd v0.14 Compatible layer.
I tried to be able to run test cases with Fluentd v0.14.

Could you check these patches?

Thanks in advance.