### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-format.gemspec
+++ b/fluent-plugin-format.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "fluentd"
+  spec.add_development_dependency "test-unit", "~> 3.2.0"
   spec.add_runtime_dependency "fluentd"
 end

--- a/lib/fluent/plugin/out_format.rb
+++ b/lib/fluent/plugin/out_format.rb
@@ -2,6 +2,11 @@ module Fluent
   class FormatOutput < Output
     Fluent::Plugin.register_output('format', self)
 
+    # Define `router` method of v0.12 to support v0.10 or earlier
+    unless method_defined?(:router)
+      define_method("router") { Fluent::Engine }
+    end
+
     config_param :tag, :string
     config_param :include_original_fields, :bool, :default => true
 
@@ -20,7 +25,7 @@ module Fluent
 
     def emit(tag, es, chain)
       es.each do |time, record|
-        Engine.emit(@tag, time, format_record(record))
+        router.emit(@tag, time, format_record(record))
       end
 
       chain.next

--- a/lib/fluent/plugin/out_format.rb
+++ b/lib/fluent/plugin/out_format.rb
@@ -6,10 +6,17 @@ module Fluent::Plugin
 
     helpers :event_emitter
 
+    DEFAULT_BUFFER_TYPE = "memory"
+
     config_param :tag, :string
     config_param :include_original_fields, :bool, :default => true
+    config_param :buffered, :bool, :default => false
 
-    CONF_KEYS = %w{type tag include_original_fields}
+    config_section :buffer do
+      config_set_default :@type, DEFAULT_BUFFER_TYPE
+    end
+
+    CONF_KEYS = %w{type tag include_original_fields buffered}
 
     def configure(conf)
       super
@@ -22,10 +29,32 @@ module Fluent::Plugin
       end
     end
 
+    def prefer_buffered_processing
+      @buffered
+    end
+
+    def formatted_to_msgpack_binary?
+      true
+    end
+
+    def multi_workers_ready?
+      true
+    end
+
+    def format(tag, time, record)
+      [time, record].to_msgpack
+    end
+
     def process(tag, es)
       es.each do |time, record|
         router.emit(@tag, time, format_record(record))
       end
+    end
+
+    def write(chunk)
+      chunk.msgpack_each {|time, record|
+        router.emit(@tag, time, format_record(record))
+      }
     end
 
     private

--- a/lib/fluent/plugin/out_format.rb
+++ b/lib/fluent/plugin/out_format.rb
@@ -1,11 +1,10 @@
-module Fluent
+require 'fluent/plugin/output'
+
+module Fluent::Plugin
   class FormatOutput < Output
     Fluent::Plugin.register_output('format', self)
 
-    # Define `router` method of v0.12 to support v0.10 or earlier
-    unless method_defined?(:router)
-      define_method("router") { Fluent::Engine }
-    end
+    helpers :event_emitter
 
     config_param :tag, :string
     config_param :include_original_fields, :bool, :default => true
@@ -23,12 +22,10 @@ module Fluent
       end
     end
 
-    def emit(tag, es, chain)
+    def process(tag, es)
       es.each do |time, record|
         router.emit(@tag, time, format_record(record))
       end
-
-      chain.next
     end
 
     private

--- a/test/test_cout_format.rb
+++ b/test/test_cout_format.rb
@@ -12,13 +12,17 @@ class FormatOutputTest < Test::Unit::TestCase
     Fluent::Test::Driver::Output.new(Fluent::Plugin::FormatOutput).configure(conf)
   end
 
-  def test_format
+  data('non-buffered' => false,
+       'buffered'     => true)
+  def test_format(data)
+    buffered = data
     d1 = create_driver %[
       type format
       tag formatted
       key1 %{key1} changed!
       new_key1 key1 -> %{key1}
       new_key2 key1 -> %{key1}, key2 -> %{key2}
+      buffered #{buffered}
     ]
 
     d1.run(default_tag: 'test') do
@@ -47,6 +51,7 @@ class FormatOutputTest < Test::Unit::TestCase
       key1 %{key1} changed!
       new_key1 key1 -> %{key1}
       new_key2 key1 -> %{key1}, key2 -> %{key2}
+      buffered #{buffered}
     ]
 
     d2.run(default_tag: 'test') do
@@ -75,6 +80,7 @@ class FormatOutputTest < Test::Unit::TestCase
       key1 %{key1} changed!
       new_key1 key1 -> %{key1}
       new_key2 key1 -> %{key1}, key2 -> %{key2}
+      buffered #{buffered}
     ]
 
     d3.run(default_tag: 'test') do

--- a/test/test_cout_format.rb
+++ b/test/test_cout_format.rb
@@ -1,4 +1,6 @@
 require 'fluent/test'
+require 'fluent/test/driver/output'
+require 'fluent/test/helpers'
 require 'fluent/plugin/out_format'
 
 class FormatOutputTest < Test::Unit::TestCase
@@ -7,7 +9,7 @@ class FormatOutputTest < Test::Unit::TestCase
   end
 
   def create_driver(conf)
-    Fluent::Test::OutputTestDriver.new(Fluent::FormatOutput).configure(conf)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::FormatOutput).configure(conf)
   end
 
   def test_format
@@ -19,9 +21,9 @@ class FormatOutputTest < Test::Unit::TestCase
       new_key2 key1 -> %{key1}, key2 -> %{key2}
     ]
 
-    d1.run do
-      d1.emit({'key1' => 'val1', 'key2' => 'val2'})
-      d1.emit({'key1' => 'val1'})
+    d1.run(default_tag: 'test') do
+      d1.feed({'key1' => 'val1', 'key2' => 'val2'})
+      d1.feed({'key1' => 'val1'})
     end
 
     assert_equal [
@@ -36,7 +38,7 @@ class FormatOutputTest < Test::Unit::TestCase
         'new_key1' => 'key1 -> val1',
         'new_key2' => 'key1 -> val1, key2 -> '
       }
-    ], d1.records
+    ], d1.events.map{|e| e.last}
 
     d2 = create_driver %[
       type format
@@ -47,9 +49,9 @@ class FormatOutputTest < Test::Unit::TestCase
       new_key2 key1 -> %{key1}, key2 -> %{key2}
     ]
 
-    d2.run do
-      d2.emit({'key1' => 'val1', 'key2' => 'val2'})
-      d2.emit({'key1' => 'val1'})
+    d2.run(default_tag: 'test') do
+      d2.feed({'key1' => 'val1', 'key2' => 'val2'})
+      d2.feed({'key1' => 'val1'})
     end
 
     assert_equal [
@@ -64,7 +66,7 @@ class FormatOutputTest < Test::Unit::TestCase
         'new_key1' => 'key1 -> val1',
         'new_key2' => 'key1 -> val1, key2 -> '
       }
-    ], d2.records
+    ], d2.events.map{|e| e.last}
 
     d3 = create_driver %[
       type format
@@ -75,9 +77,9 @@ class FormatOutputTest < Test::Unit::TestCase
       new_key2 key1 -> %{key1}, key2 -> %{key2}
     ]
 
-    d3.run do
-      d3.emit({'key1' => 'val1', 'key2' => 'val2'})
-      d3.emit({'key1' => 'val1'})
+    d3.run(default_tag: 'test') do
+      d3.feed({'key1' => 'val1', 'key2' => 'val2'})
+      d3.feed({'key1' => 'val1'})
     end
 
     assert_equal [
@@ -91,6 +93,6 @@ class FormatOutputTest < Test::Unit::TestCase
         'new_key1' => 'key1 -> val1',
         'new_key2' => 'key1 -> val1, key2 -> '
       }
-    ], d3.records
+    ], d3.events.map{|e| e.last}
   end
 end


### PR DESCRIPTION
Please take a look after #2  is merged.

---

I've tried to migrate to use v0.14 Output Plugin API.
In v0.14, Fluentd users will be able to switch non-buffered/buffered plugin by plugin configure.
Because v0.14 Output Plugin API is integrated in Fluent::Plugin::Output class.
We can choose this behavior with prefer_buffered_processing, process, and write APIs.

This PR contains major update change.
Could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks in advance.